### PR TITLE
Added XC16 support (microchip)

### DIFF
--- a/p99/p99.h
+++ b/p99/p99.h
@@ -1436,8 +1436,14 @@
  **/
 
 
+#ifndef __XC16
+    #include "p99_choice.h"
+#else
+    #define P99_CHOICE_H
+    #include "p99_id.h"
+    #include "p99_for.h"
+#endif
 
-#include "p99_choice.h"
 P99_WARN_REDUNDANT_DECLS_PUSH
 #include "p99_defarg.h"
 #include "p99_enum.h"

--- a/p99/p99_libc.h
+++ b/p99/p99_libc.h
@@ -89,6 +89,41 @@
 #  endif
 # endif
 
+#elif defined __XC16
+#define __STDC_NO_COMPLEX__
+#define P99_CSIN_BUG
+/* This is what a standard conforming C library must provide. */
+# define p00_has_feature_float_h 1
+# define p00_has_feature_iso646_h 1
+# define p00_has_feature_limits_h 1
+# define p00_has_feature_stdarg_h 1
+# define p00_has_feature_stdbool_h 1
+# define p00_has_feature_stddef_h 1
+# define p00_has_feature_stdint_h 1
+# if __STDC_HOSTED__
+#  define p00_has_feature_assert_h 1
+/* C99 requires this C11 has this conditionally */
+#  ifndef __STDC_NO_COMPLEX__
+#   define p00_has_feature_complex_h 1
+#  endif
+#  define p00_has_feature_ctype_h 1
+#  define p00_has_feature_errno_h 1
+#  define p00_has_feature_fenv_h 0
+#  define p00_has_feature_inttypes_h 1
+#  define p00_has_feature_locale_h 0
+#  define p00_has_feature_math_h 1
+#  define p00_has_feature_setjmp_h 1
+#  define p00_has_feature_signal_h 1
+#  define p00_has_feature_stdio_h 1
+#  define p00_has_feature_stdlib_h 1
+#  define p00_has_feature_string_h 1
+/* tgmath.h should be given on the compiler level */
+#  define p00_has_feature_tgmath_h 0
+#  define p00_has_feature_time_h 1
+#  define p00_has_feature_wchar_h 0
+#  define p00_has_feature_wctype_h 0
+# endif
+
 #else
 /* This is what a standard conforming C library must provide. */
 # define p00_has_feature_float_h 1


### PR DESCRIPTION
-detected XC16 compiler
-removed options that are not supported
-disabled p99_choice (compiler problem, should be fixable, all help is welcome)
-defined macro's in p99_libc to disable sin functionality

notes:
- set gcc compiler option -std=gnu99
- a inttypes.h and iso646.h in folder and link as default library location
- removed trailing ) in stdint.h file proviced by microchip
- #define p00_has_feature_tgmath_h 0 is ugly and gives a warning,...